### PR TITLE
Add AceTagGen — Suno AI prompt builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ This list aims to be a comprehensive hub for enthusiasts, researchers, and profe
 - [MuseGen](https://musegen.org) - AI tool for lyric writing and song generation.
 - [OBSIDIAN Neural](https://obsidian-neural.com): VST3 plugin for real-time AI music generation during live performance. Features 8-track MIDI-triggered sampler with text-to-audio and experimental draw-to-audio generation.
 * [Claude AI Music Skills](https://github.com/bitwize-music-studio/claude-ai-music-skills): Claude Code plugin for full-lifecycle AI music album production — lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
+- [AceTagGen](https://acetaggen.com): A free prompt builder for Suno AI. Structured inputs (mood, genre, instruments, SFX, production style) that produce a Suno-ready prompt fitting the 200-char Style field. Includes tested example library and quality-score validator.
 
 ## Conferences & Events
 


### PR DESCRIPTION
Adding AceTagGen to the Tools & Software section.

AceTagGen is a free prompt builder specifically designed for Suno AI music generation. It fits this list because:
- Purpose-built for music generation (Suno), not generic AI tooling
- Free tier, no signup required
- Actively maintained (I'm the creator)
- Fills a gap most music tools miss: respects Suno's 200-character Style field and uses empirically tested tags on v4/v4.5

Thanks for curating this list!