### PR TITLE
Add Awesome AI Startups (Audio, Voice & Music subsection) to Tools & Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ This list aims to be a comprehensive hub for enthusiasts, researchers, and profe
 - [MuseGen](https://musegen.org) - AI tool for lyric writing and song generation.
 - [OBSIDIAN Neural](https://obsidian-neural.com): VST3 plugin for real-time AI music generation during live performance. Features 8-track MIDI-triggered sampler with text-to-audio and experimental draw-to-audio generation.
 * [Claude AI Music Skills](https://github.com/bitwize-music-studio/claude-ai-music-skills): Claude Code plugin for full-lifecycle AI music album production — lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
+- [Awesome AI Startups — Audio, Voice & Music](https://github.com/nowork-studio/awesome-ai-startups#audio-voice-music) — Curated directory of indie AI music, voice, and audio products from bootstrapped startups
 
 ## Conferences & Events
 


### PR DESCRIPTION
Adds a deep-link to the Audio, Voice & Music section of [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups#audio-voice-music).

The Tools & Software section already mixes products with curated directory pages (G2 / SourceForge listings), so a focused subsection link to a curated directory of indie AI music/voice/audio products is a natural fit.

Format matches existing entries (em-dash separator, no terminal period).