### PR TITLE
Add Tunova (hosted Suno API + MCP) to Tools & Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This list aims to be a comprehensive hub for enthusiasts, researchers, and profe
 - [workmusic.ai](https://workmusic.ai): Free browser-based ambient focus music generator powered by Google Lyria. No sign-up required. Open source.
 - [webtoolz AI Music Studio](https://webtoolz.dev/music/studio): Free browser-based AI music generator. Create full songs with lyrics from text prompts, no signup required.
 - [Claude AI Music Skills](https://github.com/bitwize-music-studio/claude-ai-music-skills): Claude Code plugin for full-lifecycle AI music album production — lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
+- [Tunova](https://tunova.ai): A developer API for Suno (v5.5) — generate full songs over REST or MCP, async with HMAC-signed webhooks, billed only on successful renders (failed generations auto-refund). Zero-dependency Python & Node SDKs.
 
 ## Conferences & Events
 


### PR DESCRIPTION
Adds **Tunova** ([tunova.ai](https://tunova.ai)) to *Tools & Software* — a developer-facing hosted API for Suno music generation, which fills a gap in the list (mostly models/DIY tools, few hosted APIs devs can integrate).

- Full-song generation over **REST + a hosted MCP server** (works with Claude, Cursor, any MCP client)
- Async with HMAC-signed webhooks; **billed only on successful renders** (failed generations auto-refund)
- Zero-dependency Python & Node SDKs (`pip install tunova` / `npm i tunova`)

Single-line addition, formatted to match the section. Independent service, not affiliated with Suno.