### PR TITLE
Add AudioCraft to Tools & Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This list aims to be a comprehensive hub for enthusiasts, researchers, and profe
 - [workmusic.ai](https://workmusic.ai): Free browser-based ambient focus music generator powered by Google Lyria. No sign-up required. Open source.
 - [webtoolz AI Music Studio](https://webtoolz.dev/music/studio): Free browser-based AI music generator. Create full songs with lyrics from text prompts, no signup required.
 - [Claude AI Music Skills](https://github.com/bitwize-music-studio/claude-ai-music-skills): Claude Code plugin for full-lifecycle AI music album production — lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
+- [AudioCraft](https://audiocraft.app/) - Browser-based AI stem splitter for separating songs into vocals, drums, bass, and other instruments.
 
 ## Conferences & Events
 


### PR DESCRIPTION
Adds AudioCraft to the Tools & Software section.

AudioCraft is a browser-based AI stem splitter that separates songs into vocals, drums, bass, and other instruments for music practice, remixing, and analysis.

Disclosure: I am the creator of AudioCraft.

Website: https://audiocraft.app/
Project repository: https://github.com/DIOovo/audio