### PR TITLE
Add Minimal Music Maker to Tools & Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ This list aims to be a comprehensive hub for enthusiasts, researchers, and profe
 - [webtoolz AI Music Studio](https://webtoolz.dev/music/studio): Free browser-based AI music generator. Create full songs with lyrics from text prompts, no signup required.
 - [Claude AI Music Skills](https://github.com/bitwize-music-studio/claude-ai-music-skills): Claude Code plugin for full-lifecycle AI music album production — lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [AudioCraft](https://audiocraft.app/) - Browser-based AI stem splitter for separating songs into vocals, drums, bass, and other instruments.
+- [Minimal Music Maker](https://minimalmusic.puente-saas.com/): Free browser-based generative music app driven purely by mathematics — Conway's Game of Life generates the notes across four voices and Euler's identity drives timing and colour. 28 styles with chord progressions and beats, a full-screen stage mode for live streaming, and every pattern shares as a single URL.
 
 ## Conferences & Events
 


### PR DESCRIPTION
Adds [Minimal Music Maker](https://minimalmusic.puente-saas.com/) to **Tools & Software**.

**What it is:** a free, browser-based generative music app where the notes come from Conway's Game of Life (four independent boards → three melodic voices + one drum voice) and the timing/colour come from Euler's identity. 28 styles each carry a chord progression and a basic beat so the output stays tonal; there is a full-screen stage mode with keyboard control for live streaming, and every pattern is shareable as a single URL. No login or install needed to play.

**Why it fits this list:** it is a working, publicly available generative-music tool (rule-based rather than neural, which the list already covers via SuperCollider / Strasheela), and it has been used in production — the virtual artist Mellow ran a two-hour YouTube live stream with it as the only sound source: https://www.youtube.com/live/ix_Ebkv_ND4

Disclosure: I'm the developer (Puente Inc., Japan). One line added, existing entries untouched.